### PR TITLE
chore: refactor resources namings (excluded verbs and become more clear)

### DIFF
--- a/src/auth/routers.py
+++ b/src/auth/routers.py
@@ -36,11 +36,11 @@ router = APIRouter(prefix='/auth', tags=['Auth'])
 
 
 @router.post(
-    '/login',
+    '/token',
     responses=LOGIN_RESPONSES,
     response_model=TokenOut
 )
-async def login(
+async def token(
         email: EmailStr = Body(..., title='Email'),
         password: str = Body(..., title='Password'),
         token_response: TokenOut = Depends(login),
@@ -49,7 +49,7 @@ async def login(
 
 
 @router.post(
-    '/refresh',
+    '/token/refresh',
     responses=REFRESH_TOKEN_RESPONSES,
     response_model=TokenOut
 )
@@ -62,8 +62,8 @@ async def refresh_token(refresh_token_input: RefreshTokenInput):
     return token_response
 
 
-@router.post(
-    '/change-password',
+@router.put(
+    '/passwords',
     responses=CHANGE_PASSWORD_RESPONSES,
     status_code=status.HTTP_204_NO_CONTENT
 )
@@ -81,7 +81,7 @@ async def change_password(
 
 
 @router.post(
-    '/reset-password',
+    '/password-resets',
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def reset_password(
@@ -105,7 +105,7 @@ async def reset_password(
 
 
 @router.post(
-    '/reset-password/set-password',
+    '/password-resets/callback',
     status_code=status.HTTP_204_NO_CONTENT,
     responses=RESET_PASSWORD_CALLBACK_RESPONSES
 )

--- a/src/projects/constants.py
+++ b/src/projects/constants.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Literal
 
 
 class ProjectStatus(str, Enum):
@@ -49,3 +50,5 @@ PROJECT_FILES_MIME_TYPES = [
     "application/postscript",  # AI, EPS
     "model/stl"  # STL
 ]
+
+MODIFY_STEP_ACTIONS = Literal['set-timer', 'accept', 'reject']

--- a/src/projects/openapi.py
+++ b/src/projects/openapi.py
@@ -61,7 +61,7 @@ PROJECT_CREATE_RESPONSES: ResponseDict = {
     },
 }
 
-STEP_START_RESPONSES: ResponseDict = {
+STEP_START_ATTEMPT_RESPONSES: ResponseDict = {
     status.HTTP_409_CONFLICT: {
         'description': 'Invalid JSON in project_data field or data string must be a valid JSON.',
         'content': {
@@ -85,7 +85,7 @@ STEP_START_RESPONSES: ResponseDict = {
     },
 }
 
-STEP_SUBMIT_RESPONSES: ResponseDict = {
+STEP_SUBMIT_ATTEMPT_RESPONSES: ResponseDict = {
     status.HTTP_409_CONFLICT: {
         'description': 'Cannot submit the step due to its current state',
         'content': {
@@ -104,32 +104,14 @@ STEP_SUBMIT_RESPONSES: ResponseDict = {
     **FILE_UPLOAD_RELATED_RESPONSES
 }
 
-STEP_ACCEPT_RESPONSES: ResponseDict = {
+MODIFY_STEP_ATTEMPT_RESPONSES: ResponseDict = {
     status.HTTP_409_CONFLICT: {
-        'description': 'Cannot accept the step due to its current state',
+        'description': 'Cannot accept or reject the step due to its current state',
         'content': {
             'application/json': {
                 'examples': {
                     'step_not_submitted': {
-                        'summary': 'Attempt to accept a step that has not been submitted',
-                        'value': {
-                            'detail': 'Step has not been submitted',
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-STEP_REJECT_RESPONSES: ResponseDict = {
-    status.HTTP_409_CONFLICT: {
-        'description': 'Cannot reject the step due to its current state',
-        'content': {
-            'application/json': {
-                'examples': {
-                    'step_not_submitted': {
-                        'summary': 'Attempt to reject a step that has not been submitted',
+                        'summary': 'Attempt to accept or reject a step that has not been submitted',
                         'value': {
                             'detail': 'Step has not been submitted',
                         }

--- a/src/projects/schemas.py
+++ b/src/projects/schemas.py
@@ -4,6 +4,7 @@ from urllib.parse import urljoin
 
 from pydantic import Field, field_serializer, model_validator
 
+from projects.constants import MODIFY_STEP_ACTIONS
 from schemas import ConfiguredModel, IDModel
 from settings import settings
 from users.schemas import ShortUserInDB
@@ -155,3 +156,17 @@ class StepWithRelations(StepInDB):
     attempts: Annotated[list[StepAttemptInDB], Field(default_factory=list)]
     files: Annotated[list[FileInDB], Field(default_factory=list)]
     comments: Annotated[list[StepCommentInDB], Field(default_factory=list)]
+
+
+class StepModify(ConfiguredModel):
+    action: Annotated[MODIFY_STEP_ACTIONS, Field(None, title='Action')]
+    timer: Annotated[Optional[int], Field(None, title='New timer value', gt=0, description='Timer value in minutes')]
+    score: Annotated[Optional[int], Field(None, title='Score value', gt=0, lt=11)]
+
+    @model_validator(mode='after')
+    def validate_action(self):
+        if self.action == 'set-timer' and self.timer is None:
+            raise ValueError('timer should be provided when setting timer')
+        if self.action == 'accept' and self.score is None:
+            raise ValueError('score should be provided when accepting the attempt')
+        return self

--- a/src/teams/routers.py
+++ b/src/teams/routers.py
@@ -191,8 +191,8 @@ async def add_team_members(
     return await service.create_several_team_members(team_id, members)
 
 
-@router.post(
-    '/teams/{team_id}/members/{team_member_id}/role_name',
+@router.patch(
+    '/teams/{team_id}/members/{team_member_id}/role-name',
     tags=[TEAMS_PREFIX],
     response_model=TeamMemberInDB,
     responses={

--- a/src/users/routers.py
+++ b/src/users/routers.py
@@ -252,7 +252,7 @@ async def delete_document(
 
 
 @router.get(
-    '/users/download_users_info',
+    '/users/info-file',
     tags=[f'{USERS_PREFIX} Read'],
     responses={
         **AUTHENTICATION_RESPONSES,


### PR DESCRIPTION
### Auth
- `api/v1/auth/login` переименован на `api/v1/auth/token`
- `api/v1/auth/refresh` переименован на `api/v1/auth/token/refresh`
- POST `api/v1/auth/change-password` теперь PUT `api/v1/auth/passwords`
- `api/v1/auth/reset-password` переименован на `api/v1/auth/password-resets`
- `api/v1/auth/reset-password/set-password` переименован на `api/v1/auth/reset-password/callback`

### Project
- `api/v1/projects/{project_id}/steps/{step_num}/start` переименован в `api/v1/projects/{project_id}/steps/{step_num}/attempts`
- `api/v1/projects/{project_id}/steps/{step_num}/submit` переименован в `api/v1/projects/{project_id}/steps/{step_num}/attempts/submission`
- POST `api/v1/projects/{project_id}/steps/{step_num}/start`, POST `api/v1/projects/{project_id}/steps/{step_num}/accept`, POST `api/v1/projects/{project_id}/steps/{step_num}/reject` перенесены в единый эндпоинт PATCH `api/v1/projects/{project_id}/steps/{step_num}/attempts/submission` с соответствующими значениями для action (см. Swagger)
- `api/v1/projects/{project_id}/steps/{step_num}/download_step_files` переименован в `api/v1/projects/{project_id}/steps/{step_num}/step-files`

### Users
- `api/v1/users/download_users_info` переименован в `api/v1/users/info-file`

### Teams
- POST `api/v1/teams/{team_id}/members/{team_member_id}/role_name` перенесен в PATCH `api/v1/teams/{team_id}/members/{team_member_id}/role-name`